### PR TITLE
We should only lint src files. Updated babel-eslint.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "./node_modules/.bin/webpack --config webpack.config.production.js",
     "test": "./node_modules/karma/bin/karma start --single-run --no-auto-watch karma.config.js",
     "test_watch": "./node_modules/karma/bin/karma start --auto-watch --no-single-run karma.config.js",
-    "lint": "./node_modules/.bin/eslint ."
+    "lint": "./node_modules/.bin/eslint ./src"
   },
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "babel-core": "^5.4.5",
-    "babel-eslint": "^3.1.6",
+    "babel-eslint": "^6.0.4",
     "babel-loader": "^5.0.0",
     "eslint": "^0.21.2",
     "eslint-plugin-react": "^2.3.0",


### PR DESCRIPTION
1. After running `npm build`, the eslint will try to lint the build folder, we should only lint the src folder.
2. Babel-eslint is too old which cause linting error `TypeError: Cannot read property 'visitClass' of undefined`.
